### PR TITLE
Improvement + Fix: Personal Bests Gain

### DIFF
--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/GardenConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/GardenConfig.java
@@ -141,6 +141,11 @@ public class GardenConfig {
     public AtmosphericFilterDisplayConfig atmosphericFilterDisplay = new AtmosphericFilterDisplayConfig();
 
     @Expose
+    @ConfigOption(name = "Personal Bests", desc = "")
+    @Accordion
+    public PersonalBestsConfig personalBests = new PersonalBestsConfig();
+
+    @Expose
     @ConfigOption(name = "Plot Price", desc = "Show the price of the plot in coins when inside the Configure Plots inventory.")
     @ConfigEditorBoolean
     @FeatureToggle
@@ -210,15 +215,6 @@ public class GardenConfig {
     @ConfigEditorBoolean
     @FeatureToggle
     public boolean jacobContestSummary = true;
-
-    @Expose
-    @ConfigOption(
-        name = "Personal Best Increase FF",
-        desc = "Show in chat how much more FF you get from farming contest personal best bonus after beating the previous record."
-    )
-    @ConfigEditorBoolean
-    @FeatureToggle
-    public boolean contestPersonalBestIncreaseFF = true;
 
     // Does not have a config element!
     @Expose

--- a/src/main/java/at/hannibal2/skyhanni/config/features/garden/PersonalBestsConfig.java
+++ b/src/main/java/at/hannibal2/skyhanni/config/features/garden/PersonalBestsConfig.java
@@ -1,0 +1,27 @@
+package at.hannibal2.skyhanni.config.features.garden;
+
+import at.hannibal2.skyhanni.config.FeatureToggle;
+import com.google.gson.annotations.Expose;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigEditorBoolean;
+import io.github.notenoughupdates.moulconfig.annotations.ConfigOption;
+
+
+public class PersonalBestsConfig {
+    @Expose
+    @ConfigOption(
+        name = "Personal Best Increase FF",
+        desc = "Show in chat how much more FF you get from farming contest personal best bonus after beating the previous record."
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean contestPersonalBestIncreaseFF = true;
+
+    @Expose
+    @ConfigOption(
+        name = "Overflow Personal Bests",
+        desc = "Show in chat how much more FF you would have gotten over your previous record if personal best fortune cap was not 100"
+    )
+    @ConfigEditorBoolean
+    @FeatureToggle
+    public boolean contestPersonalBestOverflow = false;
+}

--- a/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/GardenJson.kt
+++ b/src/main/java/at/hannibal2/skyhanni/data/jsonobjects/repo/GardenJson.kt
@@ -14,7 +14,7 @@ data class GardenJson(
     @Expose val visitors: Map<String, GardenVisitor>,
     @Expose @SerializedName("organic_matter") val organicMatter: Map<NEUInternalName, Double>,
     @Expose val fuel: Map<NEUInternalName, Double>,
-    @Expose @SerializedName("max_personal_best") val maxPersonalBest: Map<CropType, Int>,
+    @Expose @SerializedName("personal_best_increment") val personalBestIncrement: Map<CropType, Int>,
 )
 
 data class GardenVisitor(

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingPersonalBestGain.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingPersonalBestGain.kt
@@ -16,9 +16,9 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
 @SkyHanniModule
 object FarmingPersonalBestGain {
-    private val config get() = GardenAPI.config
+    private val config get() = GardenAPI.config.personalBests
     private val patternGroup = RepoPattern.group("garden.contest.personal.best")
-    private val maxPB = mutableMapOf<CropType, Int>()
+    private val pbIncrement = mutableMapOf<CropType, Int>()
 
     /**
      * REGEX-TEST: §e[NPC] Jacob§f: §rYou collected §e1,400,694 §fitems! §d§lPERSONAL BEST§f!
@@ -54,9 +54,9 @@ object FarmingPersonalBestGain {
     @SubscribeEvent
     fun onRepoReload(event: RepositoryReloadEvent) {
         val data = event.getConstant<GardenJson>("Garden")
-        maxPB.clear()
-        for ((crop, pb) in data.maxPersonalBest) {
-            maxPB[crop] = pb
+        pbIncrement.clear()
+        for ((crop, pb) in data.personalBestIncrement) {
+            pbIncrement[crop] = pb
         }
     }
 
@@ -88,21 +88,26 @@ object FarmingPersonalBestGain {
     private fun checkDelayed() = DelayedRun.runNextTick { check() }
 
     private fun check() {
+        val newCollected = newCollected ?: return
         val oldCollected = oldCollected ?: return
-        val newFF = newFF?.coerceAtMost(100.0) ?: return
+        val newFF = newFF ?: return
         val crop = crop ?: return
-        val maxPB = maxPB[cropType] ?: return
+        val pbIncrement = pbIncrement[cropType] ?: return
         this.newCollected = null
         this.oldCollected = null
         this.newFF = null
         this.crop = null
 
-        val collectionPerFF = maxPB / 100
-        val oldFF = oldCollected / collectionPerFF
+        val oldFF = oldCollected / pbIncrement
+        val newOverflowFF = newCollected / pbIncrement
         val ffDiff = newFF - oldFF
+        val overflowFFDiff = newOverflowFF - oldFF
 
-        if (oldFF < 100) {
+        if (oldFF < 100 && !config.contestPersonalBestOverflow) {
             ChatUtils.chat("This is §6${ffDiff.roundTo(2)}☘ $crop Fortune §emore than previously!")
+        } else if (newOverflowFF > 100 && config.contestPersonalBestOverflow) {
+            ChatUtils.chat("You have §6${newOverflowFF.roundTo(2)}☘ $crop Fortune §eincluding overflow!")
+            ChatUtils.chat("This is §6${overflowFFDiff.roundTo(2)}☘ $crop Fortune §emore than previously!")
         }
     }
 

--- a/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingPersonalBestGain.kt
+++ b/src/main/java/at/hannibal2/skyhanni/features/garden/contest/FarmingPersonalBestGain.kt
@@ -98,8 +98,8 @@ object FarmingPersonalBestGain {
         this.newFF = null
         this.crop = null
 
-        val oldFF = oldCollected / pbIncrement
-        val newOverflowFF = newCollected / pbIncrement
+        val oldFF = oldCollected / (pbIncrement * 100)
+        val newOverflowFF = newCollected / (pbIncrement * 100)
         val ffDiff = newFF - oldFF
         val overflowFFDiff = newOverflowFF - oldFF
 


### PR DESCRIPTION
## Dependencies
- https://github.com/hannibal002/SkyHanni-REPO/pull/295

## What
Fixes incorrect personal best gain calculations if new personal best is over the max pb, adds option to show overflow personal bests.

## Changelog Improvements
+ Added overflow personal bests.  - Chissl

## Changelog Fixes
+ Fixed incorrect personal best gain calculations. - Chissl
